### PR TITLE
Fix segfault without hack

### DIFF
--- a/node/deps/v8/src/incremental-marking.cc
+++ b/node/deps/v8/src/incremental-marking.cc
@@ -355,7 +355,7 @@ void IncrementalMarking::DeactivateIncrementalWriteBarrier() {
   DeactivateIncrementalWriteBarrierForSpace(heap_->new_space());
 
   LargePage* lop = heap_->lo_space()->first_page();
-  while (lop->is_valid()) {
+  while (Page::IsValid(lop)) {
     SetOldSpacePageFlags(lop, false, false);
     lop = lop->next_page();
   }
@@ -389,7 +389,7 @@ void IncrementalMarking::ActivateIncrementalWriteBarrier() {
   ActivateIncrementalWriteBarrier(heap_->new_space());
 
   LargePage* lop = heap_->lo_space()->first_page();
-  while (lop->is_valid()) {
+  while (Page::IsValid(lop)) {
     SetOldSpacePageFlags(lop, true, is_compacting_);
     lop = lop->next_page();
   }

--- a/node/deps/v8/src/spaces-inl.h
+++ b/node/deps/v8/src/spaces-inl.h
@@ -177,7 +177,7 @@ Page* Page::Initialize(Heap* heap,
 
 bool PagedSpace::Contains(Address addr) {
   Page* p = Page::FromAddress(addr);
-  if (!p->is_valid()) return false;
+  if (!Page::IsValid(p)) return false;
   return p->owner() == this;
 }
 

--- a/node/deps/v8/src/spaces.cc
+++ b/node/deps/v8/src/spaces.cc
@@ -2276,18 +2276,18 @@ bool PagedSpace::AdvanceSweeper(intptr_t bytes_to_sweep) {
 
   intptr_t freed_bytes = 0;
   Page* p = first_unswept_page_;
-  // do {
-  //   Page* next_page = p->next_page();
-  //   if (ShouldBeSweptLazily(p)) {
-  //     if (FLAG_gc_verbose) {
-  //       PrintF("Sweeping 0x%" V8PRIxPTR " lazily advanced.\n",
-  //              reinterpret_cast<intptr_t>(p));
-  //     }
-  //     DecreaseUnsweptFreeBytes(p);
-  //     freed_bytes += MarkCompactCollector::SweepConservatively(this, p);
-  //   }
-  //   p = next_page;
-  // } while (p != anchor() && freed_bytes < bytes_to_sweep);
+  do {
+    Page* next_page = p->next_page();
+    if (ShouldBeSweptLazily(p)) {
+      if (FLAG_gc_verbose) {
+        PrintF("Sweeping 0x%" V8PRIxPTR " lazily advanced.\n",
+               reinterpret_cast<intptr_t>(p));
+      }
+      DecreaseUnsweptFreeBytes(p);
+      freed_bytes += MarkCompactCollector::SweepConservatively(this, p);
+    }
+    p = next_page;
+  } while (p != anchor() && freed_bytes < bytes_to_sweep);
 
   if (p == anchor()) {
     first_unswept_page_ = Page::FromAddress(NULL);

--- a/node/deps/v8/src/spaces.cc
+++ b/node/deps/v8/src/spaces.cc
@@ -2321,7 +2321,7 @@ HeapObject* PagedSpace::SlowAllocateRaw(int size_in_bytes) {
 
   // If there are unswept pages advance lazy sweeper then sweep one page before
   // allocating a new page.
-  if (first_unswept_page_->is_valid()) {
+  if (Page::IsValid(first_unswept_page_)) {
     AdvanceSweeper(size_in_bytes);
 
     // Retry the free list allocation.
@@ -2678,7 +2678,7 @@ LargePage* LargeObjectSpace::FindPage(Address a) {
   if (e != NULL) {
     ASSERT(e->value != NULL);
     LargePage* page = reinterpret_cast<LargePage*>(e->value);
-    ASSERT(page->is_valid());
+    ASSERT(Page::IsValid(page));
     if (page->Contains(a)) {
       return page;
     }

--- a/node/deps/v8/src/spaces.h
+++ b/node/deps/v8/src/spaces.h
@@ -308,6 +308,8 @@ class MemoryChunk {
   // Only works for addresses in pointer spaces, not data or code spaces.
   static inline MemoryChunk* FromAnyPointerAddress(Address addr);
 
+  static bool IsValid(MemoryChunk* chunk) { return chunk != NULL; }
+
   Address address() { return reinterpret_cast<Address>(this); }
 
   bool is_valid() { return address() != NULL; }
@@ -1605,7 +1607,7 @@ class PagedSpace : public Space {
   bool AdvanceSweeper(intptr_t bytes_to_sweep);
 
   bool IsSweepingComplete() {
-    return !first_unswept_page_->is_valid();
+    return !Page::IsValid(first_unswept_page_);
   }
 
   Page* FirstPage() { return anchor_.next_page(); }

--- a/node/deps/v8/test/cctest/test-spaces.cc
+++ b/node/deps/v8/test/cctest/test-spaces.cc
@@ -74,11 +74,11 @@ TEST(Page) {
   // Initialized Page has heap pointer, normally set by memory_allocator.
   p->heap_ = HEAP;
   CHECK(p->address() == page_start);
-  CHECK(p->is_valid());
+  CHECK(Page::IsValid(p));
 
   p->opaque_header = 0;
   p->SetIsLargeObjectPage(false);
-  CHECK(!p->next_page()->is_valid());
+  CHECK(!Page::IsValid(p->next_page()));
 
   CHECK(p->ObjectAreaStart() == page_start + Page::kObjectStartOffset);
   CHECK(p->ObjectAreaEnd() == page_start + Page::kPageSize);
@@ -144,7 +144,7 @@ TEST(MemoryAllocator) {
       faked_space.AreaSize(), &faked_space, NOT_EXECUTABLE);
 
   first_page->InsertAfter(faked_space.anchor()->prev_page());
-  CHECK(first_page->is_valid());
+  CHECK(Page::IsValid(first_page));
   CHECK(first_page->next_page() == faked_space.anchor());
   total_pages++;
 
@@ -155,7 +155,7 @@ TEST(MemoryAllocator) {
   // Again, we should get n or n - 1 pages.
   Page* other = memory_allocator->AllocatePage(
       faked_space.AreaSize(), &faked_space, NOT_EXECUTABLE);
-  CHECK(other->is_valid());
+  CHECK(Page::IsValid(other));
   total_pages++;
   other->InsertAfter(first_page);
   int page_count = 0;
@@ -166,7 +166,7 @@ TEST(MemoryAllocator) {
   CHECK(total_pages == page_count);
 
   Page* second_page = first_page->next_page();
-  CHECK(second_page->is_valid());
+  CHECK(Page::IsValid(second_page));
   memory_allocator->Free(first_page);
   memory_allocator->Free(second_page);
   memory_allocator->TearDown();


### PR DESCRIPTION
These changes were obtained from this [issue](https://bugzilla.redhat.com/show_bug.cgi?id=1331458).  The previous hack caused excessive memory and cpu use, which is resolved by this pull request.  Tested on Ubuntu 18.04 with gcc 7.4.0.  The patch from the linked issue was tested with gcc 6.