### PR TITLE
switch stropts.h for sys/ioctl.h

### DIFF
--- a/node/src/node_os.cc
+++ b/node/src/node_os.cc
@@ -249,7 +249,7 @@ static Handle<Value> SetupTun(const Arguments& args) {
 #include <net/if.h>
 #include <linux/if_tun.h>
 #include <memory.h>
-#include <stropts.h>
+#include <sys/ioctl.h>
 #include <asm-generic/ioctl.h>
 
 static Handle<Value> SetupTun(const Arguments& args) {


### PR DESCRIPTION
when building this, I noticed an error hit involving stropts.h, a long unsupported library and that switching out for sys/ioctl.h let the compilation continue